### PR TITLE
update 3 files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -40,11 +40,15 @@ MAING=chess_gui
 
 FINAL=yagchess
 
+YAGDIR=$(shell cd .. && pwd)
+
 all: install
 	@echo ""
 
 install: mgui
-	mv $(MAING).x ../$(FINAL).x
+	mv $(MAING).x ../$(FINAL)
+	@echo "Exporting path to bash..."
+	@grep -qF "$(YAGDIR)" ~/.bashrc || echo export PATH=\$${PATH}:$(YAGDIR) >> ~/.bashrc
 	@echo "Done."
 	
 mgui: $(MAING).cpp $(NAMEA).o $(NAMEB).o $(NAMEC).o $(NAMED).o $(NAMEIB).o
@@ -57,21 +61,25 @@ $(NAMEB).o: $(NAMEA).o $(NAMEB).hpp $(NAMEC).hpp $(NAMEB).cpp
 	$(CC) -c $(NAMEB).cpp -o $(NAMEB).o $(OPTIONS) $(CO)
 
 $(NAMEC).o: $(NAMEC).hpp $(NAMEC).cpp
-	$(CC) -c $(NAMEC).cpp -o $(NAMEC).o $(OPTIONS) $(CO)
+	$(CC) -D yagdir="\"$(YAGDIR)\"" -c $(NAMEC).cpp -o $(NAMEC).o $(OPTIONS) $(CO)
 
 $(NAMED).o: $(DEFC).hpp $(NAMEA).hpp $(NAMEB).hpp $(NAMEC).hpp $(NAMED).hpp $(NAMED).cpp
 	$(CC) -c $(NAMED).cpp -o $(NAMED).o $(OPTIONS) $(CO)
 	
 $(NAMEIB).o: $(DEFC).hpp $(NAMEA).hpp $(NAMEB).hpp $(NAMEC).hpp $(NAMED).hpp $(NAMEIB).hpp $(NAMEIB).cpp
-	$(CC) -c $(NAMEIB).cpp -o $(NAMEIB).o $(OPTIONS) $(CO) $(GTKC)
+	$(CC) -D yagdir="\"$(YAGDIR)\"" -c $(NAMEIB).cpp -o $(NAMEIB).o $(OPTIONS) $(CO) $(GTKC)
 
 clean:
 	@echo "Cleaning..."
-	@rm *.o ../$(FINAL).x
+	@rm *.o ../$(FINAL)
+	@echo "Removing from bashrc..."
+	@grep -v "$(YAGDIR)" ~/.bashrc > tempbrc
+	@cp tempbrc ~/.bashrc
+	@rm tempbrc
 	@echo "Done."
 
 help:
-	@echo "To compile $(FINAL), you need the gnu gcc compiler and the gtkmm3.0 library."
+	@echo "To compile $(FINAL) you need the gnu gcc compiler and the gtkmm3.0 library."
 	@echo "The gcc compiler is already installed on most linux distributions."
 	@echo "You can install gtkmm by using you package manager. Type:"
 	@echo "  apt-get install libgtkmm-3.0-dev"

--- a/src/chessutils.cpp
+++ b/src/chessutils.cpp
@@ -217,7 +217,7 @@ ChessUCI::~ChessUCI() {
 //setting name of chess engine and corresponding filename for saving options
 void ChessUCI::setcename(std::string fn) {
   chengname = fn;
-  filename = ".yagchess_ce_" + fn;
+  filename = std::string(yagdir) + "/.yagchess_ce_" + fn;
 }
 
 //formatting the moves for a position startpos moves command 

--- a/src/gui_interface.cpp
+++ b/src/gui_interface.cpp
@@ -28,8 +28,7 @@
 
 //static global variables (it is not an instance of any class), their scope is this file only
 static bool atwork(false);
-static std::string baserespath("resources/");
-
+static std::string baserespath(std::string(yagdir) + "/resources/");
 
 /* Methods of class ChessPGNGui
  */
@@ -608,8 +607,9 @@ void ChessTimer::stopgotimer() {
 /* Methods of ChessWindowGui class
  */
 ChessWindowGui::ChessWindowGui() {
+  std::cout << baserespath << std::endl;
   cnfgf = new ChessConfig();
-  cnfgf->initcc(".yagchess_config", ".yagchess_starthum");
+  cnfgf->initcc(std::string(yagdir) + "/.yagchess_config", std::string(yagdir) + "/.yagchess_starthum");
   starthumpl = cnfgf->getstarthumpl();
   ucianalys = nullptr;
   


### PR DESCRIPTION
Fixed makefile to pass a string variable needed by gui_interface.cpp and chessutils.cpp and add an export command to bashrc to add yagchess to $PATH. Now yagchess can be called from wherever directory.
yagchess now read configuration files in the installation directory from wherever the program is called.

In the makefile, the clean macro now will remove the export command to add yagchess to $PATH